### PR TITLE
Some Recommended Changes

### DIFF
--- a/unciv.wxs
+++ b/unciv.wxs
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?define Name = "Unciv" ?>
-<?define InstallFolder = "Unciv" ?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Language="1033"
              Manufacturer="Yair Morgenstern"
@@ -32,7 +31,7 @@
           <Shortcut Id="StartMenuShortcut"
                     Name="$(var.Name)"
                     Target="[#UncivExe]"
-                    Arguments="--data-dir=%APPDATA%\$(var.InstallFolder)"
+                    Arguments="--data-dir=[AppDataFolder][ProductName]"
                     Icon="icon.ico"
                     Directory="ApplicationProgramsFolder"
                     WorkingDirectory="INSTALLFOLDER" />
@@ -52,16 +51,16 @@
         </Feature>
     
 
-        <StandardDirectory Id="ProgramFilesFolder">
-            <Directory Id="INSTALLFOLDER" Name="$(var.InstallFolder)" />
+        <StandardDirectory Id="ProgramFiles64Folder">
+            <Directory Id="INSTALLFOLDER" Name="$(var.Name)" />
         </StandardDirectory>
 
         <StandardDirectory Id="AppDataFolder">
-            <Directory Id="APPDATAFOLDER" Name="$(var.InstallFolder)" />
+            <Directory Id="APPDATAFOLDER" Name="$(var.Name)" />
         </StandardDirectory>
 
         <StandardDirectory Id="ProgramMenuFolder">
-          <Directory Id="ApplicationProgramsFolder" Name="$(var.InstallFolder)" />
+          <Directory Id="ApplicationProgramsFolder" Name="$(var.Name)" />
         </StandardDirectory>
 
     </Package>


### PR DESCRIPTION
>[!NOTE]
> `[AppDataFolder][ProductName]` builds an absolute path of `%AppData%/Unciv`

>[!IMPORTANT]
> `[ProductName]` does not work on `Name` property. So, we have to define this instead.